### PR TITLE
Remove an 'allow' that was generating warnings

### DIFF
--- a/hematita/src/vm/mod.rs
+++ b/hematita/src/vm/mod.rs
@@ -1098,7 +1098,7 @@ macro_rules! byte_code {
 		byte_code {
 			index: 0,
 			next: move |index| {
-				#[allow(unused_mut, unused_variable, unused_assignments)]
+				#[allow(unused_assignments)]
 				{
 					let mut counter = 0;
 					let value = byte_code_inner!(index counter {$($code)*});


### PR DESCRIPTION
Rust 1.67 nightly was complaining about the allow here:

```
1101 |                 #[allow(unused_mut, unused_variable, unused_assignments)]
     |                                     ^^^^^^^^^^^^^^^ help: did you mean: `unused_variables`
```

Seems to be fine now with both 1.67 and 1.65.