### PR TITLE
Remove several dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,6 @@ dependencies = [
  "diff",
  "hashbrown",
  "itertools",
- "visibility",
 ]
 
 [[package]]
@@ -97,56 +96,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "visibility"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8881d5cc0ae34e3db2f1de5af81e5117a420d2f937506c2dc20d6f4cfb069051"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "wasi"

--- a/hematita/Cargo.toml
+++ b/hematita/Cargo.toml
@@ -15,7 +15,6 @@ authors = ["Daniel Conley <himself@danii.dev>"]
 [dependencies]
 hashbrown = "0.11.2"
 itertools = "0.10.1"
-visibility = "0.0.1"
 
 [dev-dependencies]
 diff = "0.1.12"

--- a/hematita/src/ast/lexer.rs
+++ b/hematita/src/ast/lexer.rs
@@ -78,8 +78,7 @@ impl<T> Lexer<T>
 	/// return Ok(Token::OpenParen)
 	/// # }
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn eat(&mut self) {
+	pub(crate) fn eat(&mut self) {
 		self.peeked_next();
 	}
 
@@ -98,8 +97,7 @@ impl<T> Lexer<T>
 	/// assert_eq!(lexer.source.next(), Some('e'));
 	/// ```
 	#[must_use = "all characters should be consumed, if you already peeked this, you should use `eat`"]
-	#[cfg_attr(test, visibility::make(pub))]
-	fn next(&mut self) -> Option<char> {
+	pub(crate) fn next(&mut self) -> Option<char> {
 		self.source.next()
 	}
 
@@ -133,8 +131,7 @@ impl<T> Lexer<T>
 	/// 	_ => ()
 	/// }
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn peeked_next(&mut self) -> char {
+	pub(crate) fn peeked_next(&mut self) -> char {
 		match self.next() {
 			Some(next) => next,
 			None => unreachable!("called peeked_next when there wasn't anything next")
@@ -157,8 +154,7 @@ impl<T> Lexer<T>
 	/// assert_eq!(lexer.next(), Some('h'));
 	/// assert_eq!(lexer.peek(), Some('e'));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn peek(&mut self) -> Option<char> {
+	pub(crate) fn peek(&mut self) -> Option<char> {
 		self.source.peek().map(Clone::clone)
 	}
 
@@ -181,8 +177,7 @@ impl<T> Lexer<T>
 	/// iter.eat();
 	/// assert_eq!(iter.parse_whitespace(), Some('d'));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_whitespace(&mut self) -> Option<char> {
+	pub(crate) fn parse_whitespace(&mut self) -> Option<char> {
 		loop {
 			match self.peek()? {
 				' ' | '\n' | '\r' | '\t' => self.eat(),
@@ -211,8 +206,7 @@ impl<T> Lexer<T>
 	/// assert_eq!(lexer.parse_identifier(),
 	/// 	Some(Token::Identifier("ok".to_string())));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_identifier(&mut self) -> Token {
+	pub(crate) fn parse_identifier(&mut self) -> Token {
 		let mut identifier = String::new();
 
 		while let Some('a'..='z' | 'A'..='Z' | '0'..='9' | '_') = self.peek()
@@ -259,8 +253,7 @@ impl<T> Lexer<T>
 	/// assert_eq!(lexer.parse_string(),
 	/// 	Some(Token::String("hi\n".to_owned())));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_string(&mut self) -> Option<Result<Token>> {
+	pub(crate) fn parse_string(&mut self) -> Option<Result<Token>> {
 		let delimiter = self.peeked_next();
 		let mut string = String::new();
 
@@ -302,8 +295,7 @@ impl<T> Lexer<T>
 	/// assert_eq!(lexer.parse_bracketed_string(),
 	/// 	Some(Some(Token::String("hi\\n".to_owned()))));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_bracketed_string(&mut self) -> Option<Token> {
+	pub(crate) fn parse_bracketed_string(&mut self) -> Option<Token> {
 		self.parse_bracketed().map(Token::String)
 	}
 
@@ -319,8 +311,7 @@ impl<T> Lexer<T>
 	///
 	/// assert_eq!(lexer.parse_number(), Some(Token::Integer(123)));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_number(&mut self) -> Result<Token> {
+	pub(crate) fn parse_number(&mut self) -> Result<Token> {
 		let mut number = String::new();
 		while let Some('0'..='9') = self.peek()
 			{number.push(self.peeked_next())}
@@ -343,8 +334,7 @@ impl<T> Lexer<T>
 	/// assert_eq!(lexer.parse_comment(),
 	/// 	Some(Token::Comment(" comment!".to_owned())));
 	/// ```
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_comment(&mut self) -> Option<Token> {
+	pub(crate) fn parse_comment(&mut self) -> Option<Token> {
 		match self.peek()? {
 			'[' => self.parse_bracketed().map(Token::Comment),
 			_ => {
@@ -368,8 +358,7 @@ impl<T> Lexer<T>
 	///
 	/// [string]: Self::parse_bracketed_string
 	/// [comment]: Self::parse_comment
-	#[cfg_attr(test, visibility::make(pub))]
-	fn parse_bracketed(&mut self) -> Option<String> {
+	pub(crate) fn parse_bracketed(&mut self) -> Option<String> {
 		let mut string = String::new();
 		let length = {
 			let mut length = 0usize;


### PR DESCRIPTION
It seems that the `visibility` crate was to just make certain functions public to test. I figured the easier thing to do would be to change the function visibility to just be for the crate and this *should* make sure they can't be used by other crates (the CLI included) effectively meaning they should by dropped for being unused.

The only real reason I did this is that I want to use Hematita on Windows 7 (yes, it's over 13 years old) and I had thought that some of my compiler errors being thrown by some dependencies could be fixed by removing them. Sadly no! But hopefully things compile a lot faster. That's a win too.